### PR TITLE
Add info on new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# XBox 360 Controller driver for Mac OS X
+###This driver has moved to https://github.com/360Controller/360Controller.
+###This repository remains here for reference, but is obsolete.


### PR DESCRIPTION
This just clearly marks that this repo is deprecated and has been replaced by the new org repo.
